### PR TITLE
Try to fix DDX Dalitz variation

### DIFF
--- a/include/functor/rdx/cut.h
+++ b/include/functor/rdx/cut.h
@@ -1,6 +1,6 @@
 // Author: Yipeng Sun, Svende Braun
 // License: BSD 2-clause
-// Last Change: Fri Jan 06, 2023 at 06:56 AM -0500
+// Last Change: Mon Mar 06, 2023 at 01:40 PM -0500
 // NOTE: All kinematic variables are in MeV
 
 #pragma once
@@ -299,34 +299,22 @@ Double_t WT_DD_BF(int mu_mom_id) {
 
 // DD Dalitz-inspired weights //////////////////////////////////////////////////
 
-vector<Double_t> WT_DALITZ(Double_t mDD, int b_ID) {
-  // NOTE: the 'mDD' is actual the SQUARED DD MASS!!!
+vector<Double_t> WT_DALITZ(Double_t dd_msq, Double_t dd_m_min,
+                           Double_t dd_m_max) {
   Double_t Daltweightp  = 1;
   Double_t Daltweightm  = 1;
   Double_t Daltweightqp = 1;
   Double_t Daltweightqm = 1;
 
-  if (SQRT(mDD) < 4990) {
-    Double_t min;
-    if (ABS(b_ID) == 511) {
-      min = 2010 + 1864.8;
-    }  // if B0 use Dst mass
-    if (ABS(b_ID) == 521) {
-      min = 1864.8 + 1864.8;
-    }  // if Bu use D0 mass
-    Double_t max  = 5280 - 489.;
-    Double_t min2 = min * min;
-    Double_t max2 = max * max;
+  Double_t min2 = dd_m_min * dd_m_min;
+  Double_t max2 = dd_m_max * dd_m_max;
 
-    if (mDD <= min2) return {0, 0, 0, 0};  // these are no real DD events
-
-    Daltweightp  = (1 + 2 * (sqrt((mDD - min2) / (max2 - min2)) - 0.5));
-    Daltweightm  = (1 - 2 * (sqrt((mDD - min2) / (max2 - min2)) - 0.5));
-    Daltweightqp = (8 * (sqrt((mDD - min2) / (max2 - min2)) - 0.5) *
-                    (sqrt((mDD - min2) / (max2 - min2)) - 0.5));
-    Daltweightqm = (2 - 8 * (sqrt((mDD - min2) / (max2 - min2)) - 0.5) *
-                            (sqrt((mDD - min2) / (max2 - min2)) - 0.5));
-  }
+  Daltweightp  = (1 + 2 * (sqrt((dd_msq - min2) / (max2 - min2)) - 0.5));
+  Daltweightm  = (1 - 2 * (sqrt((dd_msq - min2) / (max2 - min2)) - 0.5));
+  Daltweightqp = (8 * (sqrt((dd_msq - min2) / (max2 - min2)) - 0.5) *
+                  (sqrt((dd_msq - min2) / (max2 - min2)) - 0.5));
+  Daltweightqm = (2 - 8 * (sqrt((dd_msq - min2) / (max2 - min2)) - 0.5) *
+                          (sqrt((dd_msq - min2) / (max2 - min2)) - 0.5));
 
   return {Daltweightp, Daltweightm, Daltweightqp, Daltweightqm};
 }

--- a/include/functor/rdx/kinematic.h
+++ b/include/functor/rdx/kinematic.h
@@ -1,6 +1,6 @@
 // Author: Yipeng Sun, Svende Braun
 // License: BSD 2-clause
-// Last Change: Sat Nov 19, 2022 at 08:13 AM -0500
+// Last Change: Tue Mar 07, 2023 at 04:39 PM -0500
 
 #pragma once
 
@@ -72,75 +72,6 @@ Double_t MX_MASS(Double_t b_px, Double_t b_py, Double_t b_pz, Double_t b_pe,
   auto TD0p = PxPyPzEVector(d0_px, d0_py, d0_pz, d0_pe);
   auto TD1p = PxPyPzEVector(d1_px, d1_py, d1_pz, d1_pe);
   return (TBp - TD0p - TD1p).M();
-}
-
-// NOTE: Below the MX_MASS_DST functions use an outdated method of computing
-// mass, and are considered obsolete.
-// Computing mDD and mDX (mDX for K/K* differentiation), D*
-vector<Double_t> DD_MX_MASS_DST(Double_t mu_mom_px, Double_t mu_mom_py,
-                                Double_t mu_mom_pz, Double_t mu_mom_pe,
-                                Double_t dst_px, Double_t dst_py,
-                                Double_t dst_pz, Double_t dst_pe,
-                                int mu_gdmom_id, Double_t mu_gdmom_px,
-                                Double_t mu_gdmom_py, Double_t mu_gdmom_pz,
-                                Double_t mu_gdmom_pe, Double_t b_px,
-                                Double_t b_py, Double_t b_pz, Double_t b_pe) {
-  auto Tmumomp =
-      ROOT::Math::PxPyPzEVector(mu_mom_px, mu_mom_py, mu_mom_pz, mu_mom_pe);
-  auto     TDstp = ROOT::Math::PxPyPzEVector(dst_px, dst_py, dst_pz, dst_pe);
-  auto     Tmugdmomp = ROOT::Math::PxPyPzEVector(mu_gdmom_px, mu_gdmom_py,
-                                             mu_gdmom_pz, mu_gdmom_pe);
-  auto     TBp       = ROOT::Math::PxPyPzEVector(b_px, b_py, b_pz, b_pe);
-  Double_t mDD       = (Tmumomp + TDstp).M2();
-  Double_t mX_DD     = (TBp - TDstp - Tmumomp).M();
-
-  if (ABS(mu_gdmom_id) == 413 || ABS(mu_gdmom_id) == 423 ||
-      ABS(mu_gdmom_id) == 433) {
-    mDD   = (Tmugdmomp + TDstp).M2();
-    mX_DD = (TBp - TDstp - Tmugdmomp).M();
-  }
-
-  return {mDD, mX_DD};
-}
-
-// Computing mDD and mDX (mDX for K/K* differentiation), D0
-// NOTE: mDD is the invariant mass SQUARED
-vector<Double_t> DD_MX_MASS_D0(
-    Double_t mu_mom_px, Double_t mu_mom_py, Double_t mu_mom_pz,
-    Double_t mu_mom_pe, Double_t d_mom_px, Double_t d_mom_py, Double_t d_mom_pz,
-    Double_t d_mom_pe, int mu_gdmom_id, Double_t mu_gdmom_px,
-    Double_t mu_gdmom_py, Double_t mu_gdmom_pz, Double_t mu_gdmom_pe,
-    Double_t d_px, Double_t d_py, Double_t d_pz, Double_t d_pe, int d_mom_id,
-    Double_t b_px, Double_t b_py, Double_t b_pz, Double_t b_pe) {
-  auto Tmumomp =
-      ROOT::Math::PxPyPzEVector(mu_mom_px, mu_mom_py, mu_mom_pz, mu_mom_pe);
-  auto TDmomp =
-      ROOT::Math::PxPyPzEVector(d_mom_px, d_mom_py, d_mom_pz, d_mom_pe);
-  auto Tmugdmomp = ROOT::Math::PxPyPzEVector(mu_gdmom_px, mu_gdmom_py,
-                                             mu_gdmom_pz, mu_gdmom_pe);
-  auto TDp       = ROOT::Math::PxPyPzEVector(d_px, d_py, d_pz, d_pe);
-  auto TBp       = ROOT::Math::PxPyPzEVector(b_px, b_py, b_pz, b_pe);
-
-  Double_t mDD = 0.0, mX_DD = 0.0;
-  if (ABS(d_mom_id) == 413 || ABS(d_mom_id) == 423) {
-    mDD   = (Tmumomp + TDmomp).M2();
-    mX_DD = (TBp - TDmomp - Tmumomp).M();
-
-    if (ABS(mu_gdmom_id) == 413 || ABS(mu_gdmom_id) == 423 ||
-        ABS(mu_gdmom_id) == 433) {
-      mDD   = (Tmugdmomp + TDmomp).M2();
-      mX_DD = (TBp - TDmomp - Tmugdmomp).M();
-    }
-  } else {
-    mDD   = (Tmumomp + TDp).M2();
-    mX_DD = (TBp - TDp - Tmumomp).M();
-    if (ABS(mu_gdmom_id) == 413 || ABS(mu_gdmom_id) == 423 ||
-        ABS(mu_gdmom_id) == 433) {
-      mDD   = (Tmugdmomp + TDp).M2();
-      mX_DD = (TBp - TDp - Tmugdmomp).M();
-    }
-  }
-  return {mDD, mX_DD};
 }
 
 // Rest frame approximation ////////////////////////////////////////////////////

--- a/include/functor/rdx/truth_match.h
+++ b/include/functor/rdx/truth_match.h
@@ -28,6 +28,14 @@ bool IS_DDX(int decay_id) {
   return true;
 }
 
+bool IS_DDX_MU(int decay_id) {
+  auto ddx_ids = vector<int>{11894600, 12893600, 11894610, 12895400};
+
+  if (find(ddx_ids.begin(), ddx_ids.end(), decay_id) == ddx_ids.end())
+    return false;
+  return true;
+}
+
 bool IS_STRANGE(int decay_id) {
   auto strange_ids = vector<int>{13874020, 13674000};
 

--- a/postprocess/rdx-run2/rdx-run2_oldcut.yml
+++ b/postprocess/rdx-run2/rdx-run2_oldcut.yml
@@ -417,15 +417,14 @@ calculation:
     is_ddx_mu: bool; IS_DDX_MU(mc_id)
     # this is a naive filter:
     # we require the 2nd daughter of B is also a D meson for DDX MC only
-    ddx_add_tm_both: >-
+    ddx_add_tm: >-
         bool;
         HUNDREDS_DIGIT(ABS(b0_TrueHadron_D1_ID)) == 4;
         HUNDREDS_DIGIT(ABS(b_TrueHadron_D1_ID)) == 4
-    # for muonic DDX, require the mDD to be inside a mass window
-    ddx_add_tm_mu: >-
+    # only muonic DDK are subject to Dalitz-inspired variations
+    is_dal_variable: >-
         bool;
-        IF(is_ddx_mu, IN_RANGE(SQRT(dd_msq), dd_m_min, dd_m_max), true)
-    ddx_add_tm: bool; ddx_add_tm_mu && ddx_add_tm_both
+        IF(is_ddx_mu, IN_RANGE(SQRT(dd_msq), dd_m_min, dd_m_max), false)
     is_strange: bool; IS_STRANGE(mc_id)
 
     # FF reweighting
@@ -632,7 +631,9 @@ calculation:
     # Branching fraction weights for DD MC
     wbr_dd: double; IF(is_ddx, WT_DD_BF(mu_MC_MOTHER_ID), 1.0)
     # Dalitz-inspired variational weights for DD MC
-    tmp_dal: ^vector<double>; WT_DALITZ(dd_msq, dd_m_min, dd_m_max)
+    tmp_dal: >-
+        ^vector<double>;
+        IF(is_dal_variable, WT_DALITZ(dd_msq, dd_m_min, dd_m_max), BUILD_VEC(1.0, 1.0, 1.0, 1.0))
     wdal_lp: double; EXTRACT_ELEM(tmp_dal, 0)
     wdal_lm: double; EXTRACT_ELEM(tmp_dal, 1)
     wdal_qp: double; EXTRACT_ELEM(tmp_dal, 2)

--- a/postprocess/rdx-run2/rdx-run2_oldcut.yml
+++ b/postprocess/rdx-run2/rdx-run2_oldcut.yml
@@ -419,8 +419,8 @@ calculation:
     # we require the 2nd daughter of B is also a D meson for DDX MC only
     ddx_add_tm_both: >-
         bool;
-        is_ddx && HUNDREDS_DIGIT(ABS(b0_TrueHadron_D1_ID)) == 4;
-        is_ddx && HUNDREDS_DIGIT(ABS(b_TrueHadron_D1_ID)) == 4
+        HUNDREDS_DIGIT(ABS(b0_TrueHadron_D1_ID)) == 4;
+        HUNDREDS_DIGIT(ABS(b_TrueHadron_D1_ID)) == 4
     # for muonic DDX, require the mDD to be inside a mass window
     ddx_add_tm_mu: >-
         bool;

--- a/postprocess/rdx-run2/rdx-run2_oldcut.yml
+++ b/postprocess/rdx-run2/rdx-run2_oldcut.yml
@@ -358,7 +358,7 @@ calculation:
         SQRT(M2(b_TRUEP_X, b_TRUEP_Y, b_TRUEP_Z, b_TRUEP_E))
     q2_true: double; b0_True_Q2; b_True_Q2 # in MeV^2!
     # Inputs to Dalitz-inspired reweighting
-    dd_mass: >-
+    dd_msq: >-
         double;
         MINV2(
         b0_TrueHadron_D0_PX, b0_TrueHadron_D0_PY, b0_TrueHadron_D0_PZ, b0_TrueHadron_D0_PE,
@@ -368,7 +368,11 @@ calculation:
         b_TrueHadron_D0_PX, b_TrueHadron_D0_PY, b_TrueHadron_D0_PZ, b_TrueHadron_D0_PE,
         b_TrueHadron_D1_PX, b_TrueHadron_D1_PY, b_TrueHadron_D1_PZ, b_TrueHadron_D1_PE
         )
-    mx_mass: >-
+    # Set minimum DD mass based on reco mode.
+    dd_m_min: double; IF_VAR_EXISTS(dst_M, 2010.0 + 1864); 1864.0*2
+    dd_m_max: double; 5280 - 488.8  # at least an extra Kaon
+
+    mx_m: >-
         double;
         MX_MASS(
         b_TRUEP_X, b_TRUEP_Y, b_TRUEP_Z, b_TRUEP_E,
@@ -410,12 +414,18 @@ calculation:
         b_BKGCAT
         )
     is_ddx: bool; IS_DDX(mc_id)
+    is_ddx_mu: bool; IS_DDX_MU(mc_id)
     # this is a naive filter:
     # we require the 2nd daughter of B is also a D meson for DDX MC only
-    ddx_add_truthmatch: >-
+    ddx_add_tm_both: >-
         bool;
         is_ddx && HUNDREDS_DIGIT(ABS(b0_TrueHadron_D1_ID)) == 4;
         is_ddx && HUNDREDS_DIGIT(ABS(b_TrueHadron_D1_ID)) == 4
+    # for muonic DDX, require the mDD to be inside a mass window
+    ddx_add_tm_mu: >-
+        bool;
+        IF(is_ddx_mu, IN_RANGE(SQRT(dd_msq), dd_m_min, dd_m_max), true)
+    ddx_add_tm: bool; ddx_add_tm_mu && ddx_add_tm_both
     is_strange: bool; IS_STRANGE(mc_id)
 
     # FF reweighting
@@ -622,14 +632,14 @@ calculation:
     # Branching fraction weights for DD MC
     wbr_dd: double; IF(is_ddx, WT_DD_BF(mu_MC_MOTHER_ID), 1.0)
     # Dalitz-inspired variational weights for DD MC
-    tmp_dal: ^vector<double>; WT_DALITZ(dd_mass, b0_TRUEID); WT_DALITZ(dd_mass, b_TRUEID)
+    tmp_dal: ^vector<double>; WT_DALITZ(dd_msq, dd_m_min, dd_m_max)
     wdal_lp: double; EXTRACT_ELEM(tmp_dal, 0)
     wdal_lm: double; EXTRACT_ELEM(tmp_dal, 1)
     wdal_qp: double; EXTRACT_ELEM(tmp_dal, 2)
     wdal_qm: double; EXTRACT_ELEM(tmp_dal, 3)
 
     # K/K* variation weights (these weight up/down the K* events)
-    is_kst: bool; IF(mx_mass > 620, true, false)
+    is_kst: bool; IF(mx_m > 620, true, false)
     wkst_m: double; IF(is_kst, 0.0, 1.0)
     wkst_p: double; IF(is_kst, 2.0, 1.0)
 
@@ -769,7 +779,7 @@ global_selection:
     - trg_ok
     - global_cut_ok
     - truthmatch > 0
-    - "!is_ddx || ddx_add_truthmatch"
+    - "!is_ddx || ddx_add_tm"
     - ham_ok
 
 one_cand_only:


### PR DESCRIPTION
This should fix #123 

I change the following:

- We now can tell apart the muonic DDX from the tauonic DDX with `is_ddx_mu` flag
- For muonic DDX only, add the following global cut:
    - The `min(mDD)` is set to `1864*2` for `D0` chan, `2010 + 1864` for `D*` chan
    - The `max(mDD)` is set such that there is enough phase space to produce a `K`
- Simplify the Dalitz-weight calculation: no longer test the range of inputs

Here's `mDD` for `D0` chan
![test_d0](https://user-images.githubusercontent.com/33738176/223240172-ada9cb0e-e244-4a31-847a-cbf8d5ff46a0.png)

`mDD` for `D*` chan
![test_dst](https://user-images.githubusercontent.com/33738176/223240253-f12aae83-a657-43cc-831b-911214aa50a5.png)

@afernez @CoffeeIntoScience Please review my changes to see if they make sense.